### PR TITLE
refactor : 게시글 좋아요버튼 컴포넌트 분리

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,8 +5,7 @@
     "node": true
   },
   "parserOptions": {
-    "parser": "@babel/eslint-parser",
-    "requireConfigFile": "false"
+    "parser": "@babel/eslint-parser"
   },
   "extends": ["airbnb", "prettier", "eslint:recommended", "plugin:prettier/recommended"],
   "rules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.5.4",
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "eslint": "^8.47.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^9.0.0",
@@ -768,9 +769,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -2006,6 +2014,17 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "engines": {
         "node": ">=6.9.0"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.5.4",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "eslint": "^8.47.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^9.0.0",

--- a/src/components/Element/Post/ButtonLike.jsx
+++ b/src/components/Element/Post/ButtonLike.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+function ButtonLike({ hearted, heartCount }) {
+  const [isHeart, setIsHeart] = useState(hearted);
+  const [heartCnt, setHeartCnt] = useState(heartCount);
+
+  function handleLike() {
+    setIsHeart(prev => !prev);
+
+    // 추후에 api연결하면 변경
+    setHeartCnt(heartCnt);
+  }
+
+  return (
+    <button type="button" className={`btn-like${isHeart ? ' like' : ''}`} onClick={handleLike}>
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="transparent" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M16.9202 4.01346C16.5204 3.60579 16.0456 3.28239 15.5231 3.06175C15.0006 2.8411 14.4406 2.72754 13.875 2.72754C13.3094 2.72754 12.7494 2.8411 12.2268 3.06175C11.7043 3.28239 11.2296 3.60579 10.8298 4.01346L9.99997 4.85914L9.17017 4.01346C8.36252 3.19037 7.26713 2.72797 6.12495 2.72797C4.98277 2.72797 3.88737 3.19037 3.07973 4.01346C2.27209 4.83655 1.81836 5.9529 1.81836 7.11693C1.81836 8.28095 2.27209 9.3973 3.07973 10.2204L3.90953 11.0661L9.99997 17.273L16.0904 11.0661L16.9202 10.2204C17.3202 9.81291 17.6376 9.32909 17.8541 8.79659C18.0706 8.26409 18.182 7.69333 18.182 7.11693C18.182 6.54052 18.0706 5.96977 17.8541 5.43726C17.6376 4.90476 17.3202 4.42095 16.9202 4.01346Z"
+          stroke="#767676"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />{' '}
+      </svg>
+      <span className="cnt">{heartCnt}</span>
+    </button>
+  );
+}
+
+export default ButtonLike;

--- a/src/components/Element/Post/Post.jsx
+++ b/src/components/Element/Post/Post.jsx
@@ -3,13 +3,13 @@ import { Link, useLocation } from 'react-router-dom';
 
 import { User } from '../User';
 import ButtonOption from '../Buttons/ButtonOption';
+import ButtonLike from './ButtonLike';
 
 import './Post.scss';
 import messageCircle from '../../../assets/icon/icon-message-circle.svg';
 
 function returnContentTag() {
   const location = useLocation();
-
   if (location.pathname.includes('home')) return 'h2';
   if (location.pathname.includes('profile')) return 'h3';
   if (location.pathname.includes('detail')) return 'p';
@@ -23,46 +23,33 @@ function Post({ post }) {
   const ContentTag = returnContentTag();
 
   return (
-    <li key={id}>
-      <section id="post" className="home-post" data-postid={id}>
-        <User category="post" userName={author.username} detail={author.accountname} profileImg={author.profileImg} />
-        <div className="post-edit">
+    <section id="post" className="home-post" data-postid={id}>
+      <User category="post" userName={author.username} detail={author.accountname} profileImg={author.profileImg} />
+      <div className="post-edit">
+        <Link to="/">
+          <span className="a11y-hidden">게시글 상세보기</span>
+          {/* home : h2, profile : h3, detail : p  */}
+          <ContentTag className="post-text">{content}</ContentTag>
+          {image && (
+            <div className="img-cover">
+              <img className="post-img" src={image} alt="" />
+            </div>
+          )}
+        </Link>
+        <div className="post-icon">
+          <ButtonLike hearted={hearted} heartCount={heartCount} />
           <Link to="/">
-            <span className="a11y-hidden">게시글 상세보기</span>
-            {/* home : h2, profile : h3, detail : p  */}
-            <ContentTag className="post-text">{content}</ContentTag>
-            {image && (
-              <div className="img-cover">
-                <img className="post-img" src={image} alt="" />
-              </div>
-            )}
+            <span className="a11y-hidden">게시물 댓글 보러가기</span>
+            <img src={messageCircle} alt="" />
+            <span className="cnt">{commentCount}</span>
           </Link>
-          <div className="post-icon">
-            <button type="button" className={`btn-like${hearted ? ' like' : ''}`}>
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="transparent" xmlns="http://www.w3.org/2000/svg">
-                <path
-                  d="M16.9202 4.01346C16.5204 3.60579 16.0456 3.28239 15.5231 3.06175C15.0006 2.8411 14.4406 2.72754 13.875 2.72754C13.3094 2.72754 12.7494 2.8411 12.2268 3.06175C11.7043 3.28239 11.2296 3.60579 10.8298 4.01346L9.99997 4.85914L9.17017 4.01346C8.36252 3.19037 7.26713 2.72797 6.12495 2.72797C4.98277 2.72797 3.88737 3.19037 3.07973 4.01346C2.27209 4.83655 1.81836 5.9529 1.81836 7.11693C1.81836 8.28095 2.27209 9.3973 3.07973 10.2204L3.90953 11.0661L9.99997 17.273L16.0904 11.0661L16.9202 10.2204C17.3202 9.81291 17.6376 9.32909 17.8541 8.79659C18.0706 8.26409 18.182 7.69333 18.182 7.11693C18.182 6.54052 18.0706 5.96977 17.8541 5.43726C17.6376 4.90476 17.3202 4.42095 16.9202 4.01346Z"
-                  stroke="#767676"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />{' '}
-              </svg>
-              <span className="cnt">{heartCount}</span>
-            </button>
-            <Link to="/">
-              <span className="a11y-hidden">게시물 댓글 보러가기</span>
-              <img src={messageCircle} alt="" />
-              <span className="cnt">{commentCount}</span>
-            </Link>
-          </div>
-          {/* 날짜 처리 함수 적용 필요 */}
-          <p className="post-date">{createdAt}</p>
         </div>
+        {/* 날짜 처리 함수 적용 필요 */}
+        <p className="post-date">{createdAt}</p>
+      </div>
 
-        <ButtonOption />
-      </section>
-    </li>
+      <ButtonOption />
+    </section>
   );
 }
 

--- a/src/components/Element/Post/Post.scss
+++ b/src/components/Element/Post/Post.scss
@@ -70,6 +70,15 @@
     color: inherit;
   }
 }
+.post-icon {
+  path {
+    @include get-color(stroke, gray-color);
+  }
+  span {
+    @include get-color(color, gray-color);
+  }
+}
+
 .post-date {
   @include get-color(color, gray-color);
   font-size: map-get($font-sizes, 'size10');

--- a/src/components/Element/Post/Post.scss
+++ b/src/components/Element/Post/Post.scss
@@ -1,10 +1,6 @@
 @import '/src/styles/scss/mixin';
 
 #post {
-  margin-top: 1.25rem;
-}
-
-#post {
   position: relative;
   margin-top: 1.25rem;
   .btn-option {


### PR DESCRIPTION
### 🤚 잠깐!
- [x] PR 제목 형식 확인 [`feat: 기능 추가`]
- [x] 이슈 등록 확인
- [ ] 라벨 등록 확인

## ✏️ PR 요약
- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 : 좋아요 버튼 컴포넌트 분리
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- 좋아요유무에 따른 스타일 및 기능에 따른 좋아요 버튼의 리렌더링이 발생할때, Post 내부에서 일어나는 불필요한 리렌더링을 방지하고자 컴포넌트를 따로 생성했습니다
- post 컴포넌트를 단일로만 사용하게될 경우를 고려해서 li 태그를 없앴습니다
  - home이나 profile 페이지에서 사용할 경우, `<li key={post.id}></li>` 형태로 감싸주어야 할것 같습니다

<br>

## 🌟 전달 사항

- 좋아요버튼의 경우, 게시글에서만 사용되니 Post 폴더에만 남겨두었습니다
- 좋아요수가 반영되는 기능은 api 연결할때 수정해야 할것 같습니다

<br>

## ⚠️ Issue Number
- #1 

<br><br>
