### PR TITLE
refactor : input, errormsg  컴포넌트 마크업 및 스타일 병합

### DIFF
--- a/src/components/Element/Input/ErrorMsg.jsx
+++ b/src/components/Element/Input/ErrorMsg.jsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import './ErrorMsg.scss';
-
-function ErrorMsg({ errorText }) {
-  return <strong className="error-msg">*{errorText}</strong>;
-}
-
-export default ErrorMsg;

--- a/src/components/Element/Input/ErrorMsg.scss
+++ b/src/components/Element/Input/ErrorMsg.scss
@@ -1,7 +1,0 @@
-@import '/src/styles/scss/mixin';
-
-.error-msg {
-  @include warning-message(color, warning-color);
-  margin-top: 0.375rem;
-  display: block;
-}

--- a/src/components/Element/Input/Input.jsx
+++ b/src/components/Element/Input/Input.jsx
@@ -1,15 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './Input.scss';
 
-function Input(props) {
-  const { inputId, label, type, hasError, placeholder, required } = props;
+export function Input(props) {
+  const { inputid, label, type, placeholder, required, onChange, errorText, ...other } = props;
+  const [inpValue, setInpValue] = useState('');
 
   return (
-    <>
-      <label htmlFor={inputId}>{label}</label>
-      <input type={type || 'text'} id={inputId} className={hasError && 'error'} placeholder={placeholder} required={required} {...props} />
-    </>
+    <fieldset className="fieldset">
+      <label htmlFor={inputid}>{label}</label>
+      <input
+        type={type || 'text'}
+        id={inputid}
+        className={errorText ? 'error' : null}
+        placeholder={placeholder}
+        required={required}
+        onChange={e => setInpValue(e.target.value)}
+        value={inpValue}
+        {...other}
+      />
+      {errorText && <strong className="error-msg">*{errorText}</strong>}
+    </fieldset>
   );
 }
-
-export default Input;

--- a/src/components/Element/Input/Input.jsx
+++ b/src/components/Element/Input/Input.jsx
@@ -2,15 +2,15 @@ import React, { useState } from 'react';
 import './Input.scss';
 
 export function Input(props) {
-  const { inputid, label, type, placeholder, required, onChange, errorText, ...other } = props;
+  const { inputId, label, type, placeholder, required, onChange, errorText, ...other } = props;
   const [inpValue, setInpValue] = useState('');
 
   return (
     <fieldset className="fieldset">
-      <label htmlFor={inputid}>{label}</label>
+      <label htmlFor={inputId}>{label}</label>
       <input
         type={type || 'text'}
-        id={inputid}
+        id={inputId}
         className={errorText ? 'error' : null}
         placeholder={placeholder}
         required={required}

--- a/src/components/Element/Input/Input.jsx
+++ b/src/components/Element/Input/Input.jsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import './Input.scss';
 
 export function Input(props) {
-  const { inputId, label, type, placeholder, required, onChange, errorText, ...other } = props;
-  const [inpValue, setInpValue] = useState('');
+  const { inputId, label, type, placeholder, required, errorText, initialValue, ...other } = props;
+  const [inpValue, setInpValue] = useState(initialValue || '');
 
   return (
     <fieldset className="fieldset">

--- a/src/components/Element/Input/Input.scss
+++ b/src/components/Element/Input/Input.scss
@@ -1,31 +1,38 @@
 @import '/src/styles/scss/mixin';
 
-label {
-  @include label-tag;
-  margin-top: 1rem
-}
+.fieldset {
+  label {
+    @include label-tag;
+    margin-top: 1rem
+  }
+  
+  input {
+    display: block;
+    width: 100%;
+    @include get-color(background-color, bg-color);
+    @include get-color(color, font-color);
+    border: none;
+    border-bottom: $border-gray100-1px;
+    padding: 0.5rem 0;
 
-input {
-  display: block;
-  width: 100%;
-  @include get-color(background-color, bg-color);
-  @include get-color(color, font-color);
-  border: none;
-  border-bottom: $border-gray100-1px;
-  padding: 0.5rem 0;
-}
-
-
-input::placeholder {
-  font-size: map-get($font-sizes, "size14");
-  color: $gray100-color;
-}
-
-input:focus {
-  border-bottom: 0.0625rem solid $highlight-color;
-  outline: none;
-}
-
-input.error {
-  border-bottom-color: $warning-color-text;
+    &::placeholder {
+      font-size: map-get($font-sizes, "size14");
+      color: $gray100-color;
+    }
+    
+    &:focus {
+      border-bottom: 0.0625rem solid $highlight-color;
+      outline: none;
+    }
+    
+    &.error {
+      border-bottom-color: $warning-color-text;
+    }
+  }
+  
+  .error-msg {
+    @include warning-message(color, warning-color);
+    margin-top: 0.375rem;
+    display: block;
+  }
 }

--- a/src/components/Element/Input/Input.scss
+++ b/src/components/Element/Input/Input.scss
@@ -21,7 +21,9 @@
     }
     
     &:focus {
-      border-bottom: 0.0625rem solid $highlight-color;
+      border-bottom-width: 0.0625rem;
+      border-bottom-style: solid;
+      @include get-color(border-bottom-color, point-color);
       outline: none;
     }
     

--- a/src/components/Element/Input/index.js
+++ b/src/components/Element/Input/index.js
@@ -1,4 +1,1 @@
-import Input from './Input';
-import ErrorMsg from './ErrorMsg';
-
-export { Input, ErrorMsg };
+export { Input } from './Input';


### PR DESCRIPTION
### 🤚 잠깐!
- [x] PR 제목 형식 확인 [`feat: 기능 추가`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약
- [ ] 기능 추가 :
- [x] 마크업 & 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- 재영님 피드백으로 input 컴포넌트 리팩토링
   - fieldset으로 label, input, errormsg 감쌈
   - 입력값은 onChange, 유효성검사는 onBlur 사용할 것
   - onChange를 해당 컴포넌트에 구현하면서 부모까지 리렌더되는 것 막기
   - scss 수정

<br>

## 🌟 전달 사항

- 해당 컴포넌트 사용 예시
    
  ```
  // 에러 메세지 값
  const [nameErrorMsg, setNameErrorMsg] = useState('');
  
  // 수정 페이지 경우
  let [data, setData] = useState();
  useEffect(() => {
    if (isOnSubmit) {
      data = api();
    }
  }, [])
  
  // 유효성 검사
  const validateName = name => {
    if (name.trim().length >= 2 && name.trim().length <= 15) {
      setNameErrorMsg('');
    } else {
      setNameErrorMsg('2~15자 이내여야 합니다.');
    }
  };
  
  // input 컴포넌트
  <Input
      inputId="product-name"
      label="상품명"
      minLength="2"
      maxLength="15"
      placeholder="2~15자 이내여야 합니다."
      required
      onBlur={e => validateName(e.target.value)}
      errorText={nameErrorMsg}
      initialValue={data.product.name}
  />;
  ```

- 해당 컴포넌트 사용한 부분 다 바꿔야합니당 ^~^ ~~

<br>

## ⚠️ Issue Number
- #13 

<br><br>
